### PR TITLE
Update 0021-ckb-address-format.md

### DIFF
--- a/rfcs/0021-ckb-address-format/0021-ckb-address-format.md
+++ b/rfcs/0021-ckb-address-format/0021-ckb-address-format.md
@@ -21,12 +21,12 @@ To generate a CKB address, we firstly encode lock script to bytes array, name *p
 
 There are several methods to convert lock script into payload bytes array. We use 1 byte to identify the payload format.
 
-| format type |                   description                    |
-|:-----------:|--------------------------------------------------|
-|  0x00       | full version identifies the hash_type            |
-|  0x01       | short version for locks with popular code_hash   |
-|  0x02       | full version with hash_type = "Data", deprecated |
-|  0x04       | full version with hash_type = "Type", deprecated |
+| format type |                   description                                |
+|:-----------:|--------------------------------------------------------------|
+|  0x00       | full version identifies the hash_type                        |
+|  0x01       | short version for locks with popular code_hash, deprecated   |
+|  0x02       | full version with hash_type = "Data", deprecated             |
+|  0x04       | full version with hash_type = "Type", deprecated             |
 
 ### Full Payload Format
 
@@ -43,7 +43,7 @@ The `hash_type` field is for CKB VM version selection.
 * When the hash_type is 1, the script group matches code via type script hash and will run the code using the CKB VM version 1.
 * When the hash_type is 2, the script group matches code via data hash and will run the code using the CKB VM version 1.
 
-### Short Payload Format
+### Deprecated Short Payload Format
 
 Short payload format is a compact format which identifies common used code_hash by 1 byte code_hash_index instead of 32 bytes code_hash.
 The encode rule of short payload format is Bech32.
@@ -113,20 +113,20 @@ The human-readable part is "**ckb**" for CKB mainnet, and "**ckt**" for the test
 ## Examples and Demo Code
 
 ```yml
-== short address (code_hash_index = 0x00) test ==
-args to encode:          b39bbc0b3673c7d36450bc14cfcdad2d559c6c64
-address generated:       ckb1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jqfwyw5v
-
-== short address (code_hash_index = 0x01) test ==
-multi sign script:       00 | 01 | 02 | 03 | bd07d9f32bce34d27152a6a0391d324f79aab854 | 094ee28566dff02a012a66505822a2fd67d668fb | 4643c241e59e81b7876527ebff23dfb24cf16482
-args to encode:          4fb2be2e5d0c1a3b8694f832350a33c1685d477a
-address generated:       ckb1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqklhtgg
-
 == full address test ==
 code_hash to encode:     9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8
 hash_type to encode:     01
 with args to encode:     b39bbc0b3673c7d36450bc14cfcdad2d559c6c64
 full address generated:  ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqxwquc4
+
+== deprecated short address (code_hash_index = 0x00) test ==
+args to encode:          b39bbc0b3673c7d36450bc14cfcdad2d559c6c64
+address generated:       ckb1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jqfwyw5v
+
+== deprecated short address (code_hash_index = 0x01) test ==
+multi sign script:       00 | 01 | 02 | 03 | bd07d9f32bce34d27152a6a0391d324f79aab854 | 094ee28566dff02a012a66505822a2fd67d668fb | 4643c241e59e81b7876527ebff23dfb24cf16482
+args to encode:          4fb2be2e5d0c1a3b8694f832350a33c1685d477a
+address generated:       ckb1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqklhtgg
 
  == deprecated full address test ==
 code_hash to encode:     9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8


### PR DESCRIPTION
We should keep only one full address format to unify the address format and avoid multiple different address formats that are difficult to understand